### PR TITLE
Add per-host certificate overrides for global bindings

### DIFF
--- a/api/host/converter.go
+++ b/api/host/converter.go
@@ -19,17 +19,18 @@ func toDto(input *host.Host, globalSettings *settings.Settings) *hostResponseDto
 	}
 
 	return &hostResponseDto{
-		ID:                &input.ID,
-		Enabled:           &input.Enabled,
-		DefaultServer:     &input.DefaultServer,
-		UseGlobalBindings: &input.UseGlobalBindings,
-		DomainNames:       input.DomainNames,
-		Routes:            toRouteDtoSlice(input.Routes),
-		Bindings:          toBindingDtoSlice(input.Bindings),
-		GlobalBindings:    globalBindings,
-		VPNs:              toVpnDtoSlice(input.VPNs),
-		FeatureSet:        toFeatureSetDto(&input.FeatureSet),
-		AccessListId:      input.AccessListID,
+		ID:                                &input.ID,
+		Enabled:                           &input.Enabled,
+		DefaultServer:                     &input.DefaultServer,
+		UseGlobalBindings:                 &input.UseGlobalBindings,
+		GlobalBindingCertificateOverrides: &input.GlobalBindingCertificateOverrides,
+		DomainNames:                       input.DomainNames,
+		Routes:                            toRouteDtoSlice(input.Routes),
+		Bindings:                          toBindingDtoSlice(input.Bindings),
+		GlobalBindings:                    globalBindings,
+		VPNs:                              toVpnDtoSlice(input.VPNs),
+		FeatureSet:                        toFeatureSetDto(&input.FeatureSet),
+		AccessListId:                      input.AccessListID,
 	}
 }
 
@@ -38,16 +39,22 @@ func toDomain(input *hostRequestDto) *host.Host {
 		return nil
 	}
 
+	var certificateOverrides map[uuid.UUID]*uuid.UUID
+	if input.GlobalBindingCertificateOverrides != nil {
+		certificateOverrides = *input.GlobalBindingCertificateOverrides
+	}
+
 	return &host.Host{
-		Enabled:           getBoolValue(input.Enabled),
-		DefaultServer:     getBoolValue(input.DefaultServer),
-		UseGlobalBindings: getBoolValue(input.UseGlobalBindings),
-		DomainNames:       input.DomainNames,
-		Routes:            toRouteSlice(input.Routes),
-		Bindings:          toBindingSlice(input.Bindings),
-		VPNs:              toVpnsSlice(input.VPNs),
-		FeatureSet:        *toFeatureSet(input.FeatureSet),
-		AccessListID:      input.AccessListId,
+		Enabled:                           getBoolValue(input.Enabled),
+		DefaultServer:                     getBoolValue(input.DefaultServer),
+		UseGlobalBindings:                 getBoolValue(input.UseGlobalBindings),
+		GlobalBindingCertificateOverrides: certificateOverrides,
+		DomainNames:                       input.DomainNames,
+		Routes:                            toRouteSlice(input.Routes),
+		Bindings:                          toBindingSlice(input.Bindings),
+		VPNs:                              toVpnsSlice(input.VPNs),
+		FeatureSet:                        *toFeatureSet(input.FeatureSet),
+		AccessListID:                      input.AccessListId,
 	}
 }
 
@@ -103,6 +110,7 @@ func toBindingDto(binding *host.Binding) *bindingDto {
 	}
 
 	return &bindingDto{
+		ID:            &binding.ID,
 		Type:          &binding.Type,
 		Ip:            &binding.IP,
 		Port:          &binding.Port,

--- a/api/host/dto.go
+++ b/api/host/dto.go
@@ -7,15 +7,16 @@ import (
 )
 
 type hostRequestDto struct {
-	Enabled           *bool          `json:"enabled"`
-	DefaultServer     *bool          `json:"defaultServer"`
-	UseGlobalBindings *bool          `json:"useGlobalBindings"`
-	DomainNames       []*string      `json:"domainNames"`
-	Routes            []*routeDto    `json:"routes"`
-	Bindings          []*bindingDto  `json:"bindings"`
-	VPNs              []*vpnDto      `json:"vpns"`
-	FeatureSet        *featureSetDto `json:"featureSet"`
-	AccessListId      *uuid.UUID     `json:"accessListId"`
+	Enabled                           *bool                     `json:"enabled"`
+	DefaultServer                     *bool                     `json:"defaultServer"`
+	UseGlobalBindings                 *bool                     `json:"useGlobalBindings"`
+	GlobalBindingCertificateOverrides *map[uuid.UUID]*uuid.UUID `json:"globalBindingCertificateOverrides"`
+	DomainNames                       []*string                 `json:"domainNames"`
+	Routes                            []*routeDto               `json:"routes"`
+	Bindings                          []*bindingDto             `json:"bindings"`
+	VPNs                              []*vpnDto                 `json:"vpns"`
+	FeatureSet                        *featureSetDto            `json:"featureSet"`
+	AccessListId                      *uuid.UUID                `json:"accessListId"`
 }
 
 type routeDto struct {
@@ -64,6 +65,7 @@ type featureSetDto struct {
 }
 
 type bindingDto struct {
+	ID            *uuid.UUID        `json:"id,omitempty"`
 	Type          *host.BindingType `json:"type"`
 	Ip            *string           `json:"ip"`
 	Port          *int              `json:"port"`
@@ -77,15 +79,16 @@ type vpnDto struct {
 }
 
 type hostResponseDto struct {
-	ID                *uuid.UUID     `json:"id"`
-	Enabled           *bool          `json:"enabled"`
-	DefaultServer     *bool          `json:"defaultServer"`
-	UseGlobalBindings *bool          `json:"useGlobalBindings"`
-	DomainNames       []*string      `json:"domainNames"`
-	Routes            []*routeDto    `json:"routes"`
-	Bindings          []*bindingDto  `json:"bindings,omitempty"`
-	GlobalBindings    *[]*bindingDto `json:"globalBindings,omitempty"`
-	VPNs              []*vpnDto      `json:"vpns"`
-	FeatureSet        *featureSetDto `json:"featureSet"`
-	AccessListId      *uuid.UUID     `json:"accessListId"`
+	ID                                *uuid.UUID                `json:"id"`
+	Enabled                           *bool                     `json:"enabled"`
+	DefaultServer                     *bool                     `json:"defaultServer"`
+	UseGlobalBindings                 *bool                     `json:"useGlobalBindings"`
+	GlobalBindingCertificateOverrides *map[uuid.UUID]*uuid.UUID `json:"globalBindingCertificateOverrides"`
+	DomainNames                       []*string                 `json:"domainNames"`
+	Routes                            []*routeDto               `json:"routes"`
+	Bindings                          []*bindingDto             `json:"bindings,omitempty"`
+	GlobalBindings                    *[]*bindingDto            `json:"globalBindings,omitempty"`
+	VPNs                              []*vpnDto                 `json:"vpns"`
+	FeatureSet                        *featureSetDto            `json:"featureSet"`
+	AccessListId                      *uuid.UUID                `json:"accessListId"`
 }

--- a/api/settings/converter.go
+++ b/api/settings/converter.go
@@ -68,6 +68,7 @@ func toDto(settings *settings.Settings) *settingsDto {
 	if settings.GlobalBindings != nil {
 		for _, binding := range settings.GlobalBindings {
 			bindingsModel = append(bindingsModel, &bindingDto{
+				ID:            &binding.ID,
 				Type:          &binding.Type,
 				IP:            &binding.IP,
 				Port:          &binding.Port,
@@ -149,8 +150,15 @@ func toDomain(input *settingsDto) *settings.Settings {
 	var globalBindings []*host.Binding
 	if bindings != nil {
 		for _, binding := range bindings {
+			var id uuid.UUID
+			if binding.ID != nil {
+				id = *binding.ID
+			} else {
+				id = uuid.New()
+			}
+
 			globalBindings = append(globalBindings, &host.Binding{
-				ID:            uuid.New(),
+				ID:            id,
 				Type:          *binding.Type,
 				IP:            *binding.IP,
 				Port:          *binding.Port,

--- a/api/settings/dto.go
+++ b/api/settings/dto.go
@@ -72,6 +72,7 @@ type nginxLogsSettingsDto struct {
 }
 
 type bindingDto struct {
+	ID            *uuid.UUID        `json:"id"`
 	Type          *host.BindingType `json:"type"`
 	IP            *string           `json:"ip"`
 	Port          *int              `json:"port"`

--- a/core/host/model.go
+++ b/core/host/model.go
@@ -30,16 +30,17 @@ const (
 )
 
 type Host struct {
-	ID                uuid.UUID
-	Enabled           bool
-	DefaultServer     bool
-	UseGlobalBindings bool
-	DomainNames       []*string
-	Routes            []*Route
-	Bindings          []*Binding
-	VPNs              []*VPN
-	FeatureSet        FeatureSet
-	AccessListID      *uuid.UUID
+	ID                                uuid.UUID
+	Enabled                           bool
+	DefaultServer                     bool
+	UseGlobalBindings                 bool
+	GlobalBindingCertificateOverrides map[uuid.UUID]*uuid.UUID
+	DomainNames                       []*string
+	Routes                            []*Route
+	Bindings                          []*Binding
+	VPNs                              []*VPN
+	FeatureSet                        FeatureSet
+	AccessListID                      *uuid.UUID
 }
 
 type FeatureSet struct {

--- a/core/nginx/cfgfiles/host_certificate_file_provider.go
+++ b/core/nginx/cfgfiles/host_certificate_file_provider.go
@@ -58,6 +58,26 @@ func (p *hostCertificateFileProvider) provide(ctx *providerContext) ([]File, err
 		}
 	}
 
+	for _, h := range ctx.hosts {
+		if h.UseGlobalBindings && h.GlobalBindingCertificateOverrides != nil {
+			for _, certID := range h.GlobalBindingCertificateOverrides {
+				if certID != nil {
+					certIdStr := certID.String()
+					if !uniqueCertIds[certIdStr] {
+						uniqueCertIds[certIdStr] = true
+
+						output, err := p.buildCertificateFile(ctx.context, *certID)
+						if err != nil {
+							return nil, err
+						}
+
+						outputs = append(outputs, *output)
+					}
+				}
+			}
+		}
+	}
+
 	return outputs, nil
 }
 

--- a/core/nginx/cfgfiles/host_configuration_file_provider.go
+++ b/core/nginx/cfgfiles/host_configuration_file_provider.go
@@ -130,6 +130,15 @@ func (p *hostConfigurationFileProvider) buildBinding(
 	case host.HttpBindingType:
 		listen = fmt.Sprintf("listen %s:%d %s;", b.IP, b.Port, p.buildBindingAdditionalParams(h))
 	case host.HttpsBindingType:
+		certificateID := b.CertificateID
+		if h.UseGlobalBindings && h.GlobalBindingCertificateOverrides != nil {
+			if overrideCertID, exists := h.GlobalBindingCertificateOverrides[b.ID]; exists {
+				if overrideCertID != nil {
+					certificateID = overrideCertID
+				}
+			}
+		}
+
 		listen = fmt.Sprintf(
 			`
 				listen %s:%d ssl %s;
@@ -142,9 +151,9 @@ func (p *hostConfigurationFileProvider) buildBinding(
 			b.Port,
 			p.buildBindingAdditionalParams(h),
 			paths.Config,
-			b.CertificateID,
+			certificateID,
 			paths.Config,
-			b.CertificateID,
+			certificateID,
 		)
 	}
 

--- a/database/common/migrations/scripts/postgres/023_host_global_binding_certificate_overrides.down.sql
+++ b/database/common/migrations/scripts/postgres/023_host_global_binding_certificate_overrides.down.sql
@@ -1,0 +1,1 @@
+drop table if exists host_global_binding_certificate_override;

--- a/database/common/migrations/scripts/postgres/023_host_global_binding_certificate_overrides.up.sql
+++ b/database/common/migrations/scripts/postgres/023_host_global_binding_certificate_overrides.up.sql
@@ -1,0 +1,14 @@
+create table if not exists host_global_binding_certificate_override (
+    host_id uuid not null,
+    global_binding_id uuid not null,
+    certificate_id uuid,
+    primary key (host_id, global_binding_id),
+    constraint fk_host_global_binding_certificate_override_host
+        foreign key (host_id)
+        references host (id)
+        on delete cascade,
+    constraint fk_host_global_binding_certificate_override_certificate
+        foreign key (certificate_id)
+        references certificate (id)
+        on delete set null
+);

--- a/database/host/model.go
+++ b/database/host/model.go
@@ -8,18 +8,19 @@ import (
 type hostModel struct {
 	bun.BaseModel `bun:"host"`
 
-	ID                  uuid.UUID           `bun:"id,pk"`
-	Enabled             bool                `bun:"enabled,notnull"`
-	DefaultServer       bool                `bun:"default_server,notnull"`
-	DomainNames         []string            `bun:"domain_names,array"`
-	WebsocketSupport    bool                `bun:"websocket_support,notnull"`
-	HTTP2Support        bool                `bun:"http2_support,notnull"`
-	RedirectHTTPToHTTPS bool                `bun:"redirect_http_to_https,notnull"`
-	UseGlobalBindings   bool                `bun:"use_global_bindings,notnull"`
-	AccessListID        *uuid.UUID          `bun:"access_list_id"`
-	Bindings            []*hostBindingModel `bun:"rel:has-many,join:id=host_id"`
-	Routes              []*hostRouteModel   `bun:"rel:has-many,join:id=host_id"`
-	VPNs                []*hostVpnModel     `bun:"rel:has-many,join:id=host_id"`
+	ID                                uuid.UUID                               `bun:"id,pk"`
+	Enabled                           bool                                    `bun:"enabled,notnull"`
+	DefaultServer                     bool                                    `bun:"default_server,notnull"`
+	DomainNames                       []string                                `bun:"domain_names,array"`
+	WebsocketSupport                  bool                                    `bun:"websocket_support,notnull"`
+	HTTP2Support                      bool                                    `bun:"http2_support,notnull"`
+	RedirectHTTPToHTTPS               bool                                    `bun:"redirect_http_to_https,notnull"`
+	UseGlobalBindings                 bool                                    `bun:"use_global_bindings,notnull"`
+	AccessListID                      *uuid.UUID                              `bun:"access_list_id"`
+	Bindings                          []*hostBindingModel                     `bun:"rel:has-many,join:id=host_id"`
+	Routes                            []*hostRouteModel                       `bun:"rel:has-many,join:id=host_id"`
+	VPNs                              []*hostVpnModel                         `bun:"rel:has-many,join:id=host_id"`
+	GlobalBindingCertificateOverrides []*hostGlobalBindingCertificateOverride `bun:"rel:has-many,join:id=host_id"`
 }
 
 type hostBindingModel struct {
@@ -67,4 +68,12 @@ type hostRouteModel struct {
 	CodeContents            *string    `bun:"code_contents"`
 	CodeMainFunction        *string    `bun:"code_main_function"`
 	Enabled                 bool       `bun:"enabled,notnull"`
+}
+
+type hostGlobalBindingCertificateOverride struct {
+	bun.BaseModel `bun:"host_global_binding_certificate_override"`
+
+	HostID          uuid.UUID  `bun:"host_id,pk"`
+	GlobalBindingID uuid.UUID  `bun:"global_binding_id,pk"`
+	CertificateID   *uuid.UUID `bun:"certificate_id"`
 }

--- a/frontend/src/domain/host/components/HostGlobalBindingCertificateOverrides.tsx
+++ b/frontend/src/domain/host/components/HostGlobalBindingCertificateOverrides.tsx
@@ -1,0 +1,107 @@
+import React from "react"
+import { Card, Empty, Form } from "antd"
+import ValidationResult from "../../../core/validation/ValidationResult"
+import { HostBinding, HostBindingType } from "../model/HostRequest"
+import PaginatedSelect from "../../../core/components/select/PaginatedSelect"
+import CertificateService from "../../certificate/CertificateService"
+import PageResponse from "../../../core/pagination/PageResponse"
+import { CertificateResponse } from "../../certificate/model/CertificateResponse"
+import TagGroup from "../../../core/components/taggroup/TagGroup"
+
+export interface HostGlobalBindingCertificateOverridesProps {
+    globalBindings?: HostBinding[]
+    validationResult: ValidationResult
+}
+
+export default class HostGlobalBindingCertificateOverrides extends React.Component<HostGlobalBindingCertificateOverridesProps> {
+    private readonly certificateService: CertificateService
+
+    constructor(props: HostGlobalBindingCertificateOverridesProps) {
+        super(props)
+        this.certificateService = new CertificateService()
+    }
+
+    private getBindingLabel(binding: HostBinding): string {
+        const protocol = binding.type === HostBindingType.HTTPS ? "HTTPS" : "HTTP"
+        return `${protocol} - ${binding.ip}:${binding.port}`
+    }
+
+    private fetchCertificates = async (search: string, page: number): Promise<PageResponse<CertificateResponse>> => {
+        return this.certificateService.list(undefined, page, search)
+    }
+
+    private renderBinding(binding: HostBinding, index: number) {
+        const { validationResult } = this.props
+        const fieldName = ["globalBindingCertificateOverrides", index, "certificate"]
+
+        if (binding.type !== HostBindingType.HTTPS) {
+            return null
+        }
+
+        return (
+            <Card key={binding.id || `binding-${index}`} style={{ marginBottom: 16 }} size="small">
+                <Form.Item
+                    name={fieldName}
+                    label={this.getBindingLabel(binding)}
+                    validateStatus={validationResult.getStatus(
+                        `globalBindingCertificateOverrides[${index}].certificate`,
+                    )}
+                    help={validationResult.getMessage(`globalBindingCertificateOverrides[${index}].certificate`)}
+                    labelCol={{ span: 8 }}
+                    wrapperCol={{ span: 16 }}
+                >
+                    <PaginatedSelect<CertificateResponse>
+                        placeholder="Use default certificate"
+                        allowEmpty={true}
+                        pageProvider={(pageSize, pageNumber, searchTerms) =>
+                            this.fetchCertificates(searchTerms || "", pageNumber)
+                        }
+                        itemKey={certificate => certificate.id}
+                        itemDescription={certificate => <TagGroup values={certificate.domainNames} maximumSize={1} />}
+                    />
+                </Form.Item>
+                <Form.Item
+                    name={["globalBindingCertificateOverrides", index, "bindingId"]}
+                    hidden
+                    initialValue={binding.id}
+                >
+                    <input type="hidden" value={binding.id} />
+                </Form.Item>
+            </Card>
+        )
+    }
+
+    render() {
+        const { globalBindings } = this.props
+
+        if (!globalBindings || globalBindings.length === 0) {
+            return (
+                <Empty
+                    description="No global bindings configured. Please configure global bindings in the settings."
+                    style={{ marginTop: 20, marginBottom: 20 }}
+                />
+            )
+        }
+
+        const httpsBindings = globalBindings.filter(b => b.type === HostBindingType.HTTPS)
+
+        if (httpsBindings.length === 0) {
+            return (
+                <Empty
+                    description="No HTTPS global bindings configured. Certificate overrides are only available for HTTPS bindings."
+                    style={{ marginTop: 20, marginBottom: 20 }}
+                />
+            )
+        }
+
+        return (
+            <div style={{ marginTop: 16 }}>
+                <p style={{ marginBottom: 16, color: "#666" }}>
+                    Select a certificate for each HTTPS binding to override the default certificate. Leave empty to use
+                    the certificate configured in the global binding.
+                </p>
+                {globalBindings.map((binding, index) => this.renderBinding(binding, index))}
+            </div>
+        )
+    }
+}

--- a/frontend/src/domain/host/model/HostFormValues.ts
+++ b/frontend/src/domain/host/model/HostFormValues.ts
@@ -43,10 +43,16 @@ export interface HostFormVpn {
     host?: string
 }
 
+export interface HostFormGlobalBindingCertificateOverride {
+    bindingId: string
+    certificate?: CertificateResponse
+}
+
 export default interface HostFormValues {
     enabled: boolean
     defaultServer: boolean
     useGlobalBindings: boolean
+    globalBindingCertificateOverrides: HostFormGlobalBindingCertificateOverride[]
     domainNames: string[]
     routes: HostFormRoute[]
     bindings: HostFormBinding[]

--- a/frontend/src/domain/host/model/HostFormValuesDefaults.ts
+++ b/frontend/src/domain/host/model/HostFormValuesDefaults.ts
@@ -6,6 +6,7 @@ export function hostFormValuesDefaults(): HostFormValues {
         enabled: true,
         defaultServer: false,
         useGlobalBindings: true,
+        globalBindingCertificateOverrides: [],
         domainNames: [""],
         vpns: [],
         bindings: [

--- a/frontend/src/domain/host/model/HostRequest.ts
+++ b/frontend/src/domain/host/model/HostRequest.ts
@@ -24,6 +24,7 @@ export interface HostFeatureSet {
 }
 
 export interface HostBinding {
+    id?: string
     type: HostBindingType
     ip: string
     port: number
@@ -79,6 +80,7 @@ export default interface HostRequest {
     enabled: boolean
     defaultServer: boolean
     useGlobalBindings: boolean
+    globalBindingCertificateOverrides?: Record<string, string | null>
     domainNames?: string[]
     routes: HostRoute[]
     bindings?: HostBinding[]


### PR DESCRIPTION
Allows hosts using global bindings to override the SSL certificate on a per-binding basis. This enables multiple domains to share the same global binding configuration while using different certificates.

Changes:
* New globalBindingCertificateOverrides field on hosts (maps binding ID to certificate ID)
* Database migration for storing overrides
* Frontend UI for selecting certificates per HTTPS global binding